### PR TITLE
Add @babel/runtime dep to graphql-api package

### DIFF
--- a/services/graphql-api/package.json
+++ b/services/graphql-api/package.json
@@ -6,6 +6,7 @@
     "start": "node ."
   },
   "dependencies": {
+    "@babel/runtime": "^7.12.5",
     "apollo-server": "^2.10.0",
     "graphql": "^14.6.0",
     "graphql-tools": "^4.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,6 +1057,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.7":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
@@ -9029,6 +9036,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
When attempting to run `yarn build` the following error occurs:

`error @monorepo-starter/graphql-api "@babel/runtime/helpers/taggedTemplateLiteral" is imported by "src/index.js" but the package is not specified in dependencies or peerDependencies`

Adding `@babel/runtime` to the `graphql-api` fixes this. More info as to why [here.](https://babeljs.io/docs/en/babel-plugin-transform-runtime#why)